### PR TITLE
Use return instead of raise StopIteration (PEP479)

### DIFF
--- a/articlemeta/client.py
+++ b/articlemeta/client.py
@@ -150,7 +150,7 @@ class RestfulClient(object):
             identifiers = self._do_request(url, params=params).get('objects', [])
 
             if len(identifiers) == 0:
-                raise StopIteration
+                return
 
             for identifier in identifiers:
 
@@ -771,7 +771,7 @@ class ThriftClient(object):
             )
 
             if len(identifiers) == 0:
-                raise StopIteration
+                return
 
             for identifier in identifiers:
 


### PR DESCRIPTION
That's required for Python 3.7.0, which no longer accepts raising
StopIteration

It works fine in Python 2.7.15, 3.4.9, 3.5.5 and 3.6.6