### PR TITLE
Corrigi o retorno da função ``date_pagination`` quando a data tem o mesmo ano.

### DIFF
--- a/articlemeta/client.py
+++ b/articlemeta/client.py
@@ -75,7 +75,7 @@ def dates_pagination(from_date, until_date):
 
 class RestfulClient(object):
 
-    ARTICLEMETA_URL = 'http://127.0.0.1:8000'
+    ARTICLEMETA_URL = 'http://articlemeta.scielo.org'
     JOURNAL_ENDPOINT = '/api/v1/journal'
     ARTICLE_ENDPOINT = '/api/v1/article'
     ARTICLES_ENDPOINT = '/api/v1/articles'

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ tests_require = []
 
 setuptools.setup(
     name="articlemetaapi",
-    version="1.26.6",
+    version="1.26.7",
     description="SciELO ArticleMeta SDK for Python",
     author="SciELO",
     author_email="scielo-dev@googlegroups.com",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -17,3 +17,13 @@ class ClientTest(unittest.TestCase):
         ]
 
         self.assertEqual(sorted(expected), sorted(result))
+
+    def test_dates_pagination_same_year(self):
+
+        result = [i for i in client.dates_pagination('2020-05-15', '2020-05-16')]
+
+        expected = [
+            ('2020-05-15', '2020-05-16'),
+        ]
+
+        self.assertEqual(sorted(expected), sorted(result))


### PR DESCRIPTION
Essa correção é um tanto quando diferente, ela corrigi uma função que ajusta comportamento do **AM(Article Meta)**. 

Essa API(função) ela cria uma páginação no **deslocamento** evitando que o cursor do Mongo se torne um "gargalo". 

Identificamos em uma atividade de coleta dos dados no **AM** que para o mesmo ano de coleta o retorno era sempre até o final do ano informado.

Para realizar um teste manual: 

```
from articlemeta.client import RestfulClient

art = RestfulClient()

for d in art.documents(from_date='2020-05-15', until_date='2020-05-16'):
    print(d.processing_date)
````

Ticket relacionado: https://github.com/scieloorg/articlemetaapi/issues/11